### PR TITLE
polish.Container.selectEntriesWhileTouchScrolling

### DIFF
--- a/enough-polish-j2me/source/src/de/enough/polish/ui/Container.java
+++ b/enough-polish-j2me/source/src/de/enough/polish/ui/Container.java
@@ -67,6 +67,10 @@ public class Container extends Item {
 		//#define tmp.useTable
 	//#endif
 	
+	//#ifndef polish.Container.selectEntriesWhileTouchScrolling
+		//#define polish.Container.selectEntriesWhileTouchScrolling = true
+	//#endif
+	
 	/** constant for normal scrolling (0) */
 	public static final int SCROLL_DEFAULT = 0;
 	/** constant for smooth scrolling (1) */
@@ -2409,7 +2413,7 @@ public class Container extends Item {
 		//return super.handleKeyRepeated(keyCode, gameAction);
 	}
 	
-	//#if polish.Container.useTouchFocusHandling
+	//#if !polish.Container.selectEntriesWhileTouchScrolling
 	/**
 	 * Focuses the first visible item in the given vertical minimum and maximum offsets.
 	 * 
@@ -2513,7 +2517,7 @@ public class Container extends Item {
 			return false;
 		}
 		
-		//#if polish.Container.useTouchFocusHandling
+		//#if !polish.Container.selectEntriesWhileTouchScrolling
 		if(this.focusedIndex == -1) {
 			int verticalMin = getAbsoluteY();
 			int verticalMax = verticalMin + getScrollHeight();
@@ -3883,7 +3887,7 @@ public class Container extends Item {
 			return true;
 		}
 		
-		//#if polish.Container.useTouchFocusHandling
+		//#if !polish.Container.selectEntriesWhileTouchScrolling
 		if(item != null) {
 	   		 focusChild(-1);
 	   		 //#if polish.blackberry

--- a/enough-polish-website/site/source/docs/gui-touchsupport.html
+++ b/enough-polish-website/site/source/docs/gui-touchsupport.html
@@ -161,6 +161,18 @@ public class GlobalEventHandler implements EventListener {
 }
 </pre>
 	
+	<h2 id="virtualkeyboard">Touch Support and Focus</h2>
+	<p>
+	By default, J2ME Polish focuses items while dragging a scrollable area (e.g. a screen) and keeps the focus while scrolling. 
+	To disable this feature you can set the following preprocessing variable :
+	<pre>
+	<variable name="polish.Container.selectEntriesWhileTouchScrolling" value="false" />
+	</pre>
+	With this preprocessing variable set to false, the focus is released when a scrollable area is dragged or scrolled.
+	When the up/down key is pressed on a touch device with directional keys / trackpad (e.g. the BlackBerry Torch) the focus is restored to the first
+	visible item.  
+	</p>
+	
 	<h2 id="virtualkeyboard">Virtual keyboard</h2>
 	<p>
 	When using TextFields in your Screens you can also use an <a href="gui-item-textfield.html#textfield-virtualkeyboard">virtual keyboard</a> to enter text. 


### PR DESCRIPTION
I reworked polish.Container.useTouchFocusHandling to polish.Container.selectEntriesWhileTouchScrolling.

The variable polish.Container.selectEntriesWhileTouchScrolling is set intially to true and must be set explicitly to false in the build.xml to enable focus release on dragging/scrolling.

I also added documentation describing the feature to enough-polish-website/site/docs/gui-touchsupport.html.
