### PR TITLE
New focus behaviour on touch scrolling and feature selectEntriesWhileTouchScrolling

### DIFF
--- a/enough-polish-j2me/source/src/de/enough/polish/ui/Container.java
+++ b/enough-polish-j2me/source/src/de/enough/polish/ui/Container.java
@@ -67,10 +67,6 @@ public class Container extends Item {
 		//#define tmp.useTable
 	//#endif
 	
-	//#ifndef polish.Container.selectEntriesWhileTouchScrolling
-		//#define polish.Container.selectEntriesWhileTouchScrolling = true
-	//#endif
-	
 	/** constant for normal scrolling (0) */
 	public static final int SCROLL_DEFAULT = 0;
 	/** constant for smooth scrolling (1) */

--- a/enough-polish-j2me/source/src/de/enough/polish/ui/Container.java
+++ b/enough-polish-j2me/source/src/de/enough/polish/ui/Container.java
@@ -67,6 +67,10 @@ public class Container extends Item {
 		//#define tmp.useTable
 	//#endif
 	
+	//#ifndef polish.Container.selectEntriesWhileTouchScrolling
+		//#define polish.Container.selectEntriesWhileTouchScrolling = true
+	//#endif
+	
 	/** constant for normal scrolling (0) */
 	public static final int SCROLL_DEFAULT = 0;
 	/** constant for smooth scrolling (1) */
@@ -2409,7 +2413,7 @@ public class Container extends Item {
 		//return super.handleKeyRepeated(keyCode, gameAction);
 	}
 	
-	//#if polish.Container.useTouchFocusHandling
+	//#if !polish.Container.selectEntriesWhileTouchScrolling
 	/**
 	 * Focuses the first visible item in the given vertical minimum and maximum offsets.
 	 * 
@@ -2513,7 +2517,7 @@ public class Container extends Item {
 			return false;
 		}
 		
-		//#if polish.Container.useTouchFocusHandling
+		//#if !polish.Container.selectEntriesWhileTouchScrolling
 		if(this.focusedIndex == -1) {
 			int verticalMin = getAbsoluteY();
 			int verticalMax = verticalMin + getScrollHeight();
@@ -3883,7 +3887,7 @@ public class Container extends Item {
 			return true;
 		}
 		
-		//#if polish.Container.useTouchFocusHandling
+		//#if !polish.Container.selectEntriesWhileTouchScrolling
 		if(item != null) {
 	   		 focusChild(-1);
 	   		 //#if polish.blackberry

--- a/enough-polish-website/site/source/docs/gui-touchsupport.html
+++ b/enough-polish-website/site/source/docs/gui-touchsupport.html
@@ -161,6 +161,18 @@ public class GlobalEventHandler implements EventListener {
 }
 </pre>
 	
+	<h2 id="virtualkeyboard">Touch Support and Focus</h2>
+	<p>
+	By default, J2ME Polish focuses items while dragging a scrollable area (e.g. a screen) and keeps the focus while scrolling. 
+	To disable this feature you can set the following preprocessing variable :
+	<pre>
+	<variable name="polish.Container.selectEntriesWhileTouchScrolling" value="false" />
+	</pre>
+	With this preprocessing variable set to false, the focus is released when a scrollable area is dragged or scrolled.
+	When the up/down key is pressed on a touch device with directional keys / trackpad (e.g. the BlackBerry Torch) the focus is restored to the first
+	visible item.  
+	</p>
+	
 	<h2 id="virtualkeyboard">Virtual keyboard</h2>
 	<p>
 	When using TextFields in your Screens you can also use an <a href="gui-item-textfield.html#textfield-virtualkeyboard">virtual keyboard</a> to enter text. 

--- a/enough-polish-website/site/source/docs/gui-touchsupport.html
+++ b/enough-polish-website/site/source/docs/gui-touchsupport.html
@@ -163,14 +163,14 @@ public class GlobalEventHandler implements EventListener {
 	
 	<h2 id="virtualkeyboard">Touch Support and Focus</h2>
 	<p>
-	By default, J2ME Polish focuses items while dragging a scrollable area (e.g. a screen) and keeps the focus while scrolling. 
+	By default, J2ME Polish clears the focus while dragging a scrollable area (e.g. a screen).
+	When the up/down key is pressed on a touch device with directional keys / trackpad (e.g. the BlackBerry Torch) 
+	the focus is restored to the first visible item.   
 	To disable this feature you can set the following preprocessing variable :
 	<pre>
-	<variable name="polish.Container.selectEntriesWhileTouchScrolling" value="false" />
+	<variable name="polish.Container.selectEntriesWhileTouchScrolling" value="true" />
 	</pre>
-	With this preprocessing variable set to false, the focus is released when a scrollable area is dragged or scrolled.
-	When the up/down key is pressed on a touch device with directional keys / trackpad (e.g. the BlackBerry Torch) the focus is restored to the first
-	visible item.  
+	With this preprocessing variable set to true, the focus remains on the last selected item when a scrollable area is dragged or scrolled.
 	</p>
 	
 	<h2 id="virtualkeyboard">Virtual keyboard</h2>
@@ -188,7 +188,7 @@ public class GlobalEventHandler implements EventListener {
 	
 	<h2 id="JavaDoc">JavaDoc</h2>
 	<ul>
-		<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/ui/UiAccess.html">UiAccess</a></li>
+		"build/Generic/AnyPhone/de/source/de/enough/polish/test/Test.java"<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/ui/UiAccess.html">UiAccess</a></li>
 		<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/event/UiEventListener.html">UiEventListener</a></li>
 		<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/event/EventListener.html">EventListener</a></li>
 		<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/event/EventManager.html">EventManager</a></li>

--- a/enough-polish-website/site/source/docs/gui-touchsupport.html
+++ b/enough-polish-website/site/source/docs/gui-touchsupport.html
@@ -188,7 +188,7 @@ public class GlobalEventHandler implements EventListener {
 	
 	<h2 id="JavaDoc">JavaDoc</h2>
 	<ul>
-		"build/Generic/AnyPhone/de/source/de/enough/polish/test/Test.java"<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/ui/UiAccess.html">UiAccess</a></li>
+		<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/ui/UiAccess.html">UiAccess</a></li>
 		<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/event/UiEventListener.html">UiEventListener</a></li>
 		<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/event/EventListener.html">EventListener</a></li>
 		<li><a href="<%= javadocdir %>/javadoc/j2me/de/enough/polish/event/EventManager.html">EventManager</a></li>


### PR DESCRIPTION
The new focus behaviour on touch scrolling looses the focus of a Container when the Container is scrolled/dragged. When the up/down key is pressed on a touch device with directional keys / trackpad (e.g. the BlackBerry Torch) the focus is restored to the first visible item.   

The setting of the preprocessing variable selectEntriesWhileTouchScrolling to true sets the focus behaviour to the old one, setting the focus on the selected entry and leaving it there while scrolling.

The website documentation documents this behaviour.
