### PR TITLE
Fixed ErrorOutOfBoundsException on default package in jar package listing

### DIFF
--- a/enough-polish-build/source/src/de/enough/polish/util/JarUtil.java
+++ b/enough-polish-build/source/src/de/enough/polish/util/JarUtil.java
@@ -340,9 +340,11 @@ public final class JarUtil {
 			String name = entry.getName();
 			if (name.endsWith(".class")) {
 				int endPos = name.lastIndexOf(File.separatorChar);
-				name = name.substring( 0, endPos );
-				name = name.replace(File.separatorChar, '.');
-				packageNames.put( name, name );
+				if(endPos >= 0) {
+					name = name.substring( 0, endPos );
+					name = name.replace(File.separatorChar, '.');
+					packageNames.put( name, name );
+				}
 			}
 		}
 		return (String[]) packageNames.values().toArray( new String[ packageNames.size() ] );


### PR DESCRIPTION
Fixed an ErrorOutOfBoundsException when a jar file with default package is listed for packages. This happened with the Dash-O jar file which seems to have only the default package.
