### PR TITLE
Loose focus on scroll feature improvement

### DIFF
--- a/enough-polish-j2me/source/src/de/enough/polish/ui/Container.java
+++ b/enough-polish-j2me/source/src/de/enough/polish/ui/Container.java
@@ -163,6 +163,14 @@ public class Container extends Item {
 	private int scrollStartYOffset;
 	private long scrollDuration = 300; // ms
 	
+	
+	//#if !polish.Container.selectEntriesWhileTouchScrolling
+	/**
+	 * the minimum drag distance before the focus is cleared while dragging  
+	 */
+	private static final int minimumDragDistance = Math.min(Display.getScreenWidth(),Display.getScreenHeight())/10;
+	//#endif
+	
 	/**
 	 * Creates a new empty container.
 	 */
@@ -3885,11 +3893,14 @@ public class Container extends Item {
 		
 		//#if !polish.Container.selectEntriesWhileTouchScrolling
 		if(item != null) {
-	   		 focusChild(-1);
-	   		 //#if polish.blackberry
-	   		 //# ((BaseScreen)(Object)Display.getInstance()).notifyFocusSet(null);
-	   		 //#endif
-	   		 UiAccess.init(item, item.getAvailableWidth(), item.getAvailableWidth(), item.getAvailableHeight());
+			int dragDistance = Math.abs(relY - this.lastPointerPressY);
+			if(dragDistance > minimumDragDistance) {
+				focusChild(-1);
+		   		//#if polish.blackberry
+		   		//# ((BaseScreen)(Object)Display.getInstance()).notifyFocusSet(null);
+		   		//#endif
+		   		UiAccess.init(item, item.getAvailableWidth(), item.getAvailableWidth(), item.getAvailableHeight());
+			}
    	  	}
 		//#endif
 		


### PR DESCRIPTION
The default behaviour when dragging a Container removed the focus instantly once the container was dragged. 

This resulted in compilcations on Android devices as the slightest drag removed the focus and thus made commands on container items impossible.

This was resolved by adding a minimum drag distance before the focus is removed. This minimum distance is 10% of the lowest part of the screen resolution.
