### PR TITLE
Fixed bug where polish.Container.dontUseNumberKeys did not work as ex…

### DIFF
--- a/enough-polish-j2me/source/src/de/enough/polish/ui/ChoiceGroup.java
+++ b/enough-polish-j2me/source/src/de/enough/polish/ui/ChoiceGroup.java
@@ -1444,7 +1444,13 @@ implements Choice
 				//#endif
 			}
 		//#else
-			processed = super.handleKeyPressed(keyCode, gameAction);
+			//#if polish.Container.dontUseNumberKeys != true
+				if ( keyCode < Canvas.KEY_NUM0 || keyCode > Canvas.KEY_NUM9 ) {
+					processed = super.handleKeyPressed(keyCode, gameAction);
+				}
+			//#else
+				processed = super.handleKeyPressed(keyCode, gameAction);
+			//#endif
 		//#endif
 		//#debug
 		System.out.println("ChoiceGroup: container handled keyPressEvent: " + processed);


### PR DESCRIPTION
…pected (pressing 2,4,6,8 in ChoiceGroup was sometimes treated as direction key instead of item selection shortcut)
